### PR TITLE
Use puppet to select apache username

### DIFF
--- a/nubis/puppet/cron.pp
+++ b/nubis/puppet/cron.pp
@@ -1,4 +1,4 @@
 cron::hourly { "${project_name}-dashboard":
- user    => 'www-data',
+ user    => $apache::params::user,
  command => "nubis-cron ${project_name}-dashboard /var/www/${project_name}/dashboard.py > /var/www/${project_name}/dashboard.html",
 }


### PR DESCRIPTION
$apache::params::user is a better choice for username, instaead of hard-coding 'www-data' or similar